### PR TITLE
Fixed git describe --tags returning an invalid semver string

### DIFF
--- a/version-update.py
+++ b/version-update.py
@@ -73,7 +73,7 @@ def main():
     [verify_env_var_presence(e) for e in env_list]
 
     try:
-        latest = git("describe", "--tags").decode().strip().rsplit("-", 1)[0]
+        latest = git("describe", "--tags").decode().strip().rsplit("-", 1)[0].replace("-", ".")
     except subprocess.CalledProcessError:
         # Default to version 1.0.0 if no tags are available
         version = "1.0.0"

--- a/version-update.py
+++ b/version-update.py
@@ -73,7 +73,7 @@ def main():
     [verify_env_var_presence(e) for e in env_list]
 
     try:
-        latest = git("describe", "--tags").decode().strip()
+        latest = git("describe", "--tags").decode().strip().rsplit("-", 1)[0]
     except subprocess.CalledProcessError:
         # Default to version 1.0.0 if no tags are available
         version = "1.0.0"


### PR DESCRIPTION
This PR is for fixing the issue where 

`git describe --tags` 

returns: `1.0-77-g359d01d`

which is invalid semver string. 
 