### PR TITLE
Prevent incrementing non semver tags

### DIFF
--- a/version-update.py
+++ b/version-update.py
@@ -22,7 +22,7 @@ def extract_gitlab_url_from_project_url():
 def extract_merge_request_id_from_commit():
     message = git("log", "-1", "--pretty=%B")
     matches = re.search(r'(\S*\/\S*!)(\d+)', message.decode("utf-8"), re.M|re.I)
-    
+
     if matches == None:
         raise Exception(f"Unable to extract merge request from commit message: {message}")
 
@@ -66,14 +66,14 @@ def tag_repo(tag):
 
     git("remote", "set-url", "--push", "origin", push_url)
     git("tag", tag)
-    git("push", "origin", tag)        
+    git("push", "origin", tag)
 
 def main():
     env_list = ["CI_REPOSITORY_URL", "CI_PROJECT_ID", "CI_PROJECT_URL", "CI_PROJECT_PATH", "NPA_USERNAME", "NPA_PASSWORD"]
     [verify_env_var_presence(e) for e in env_list]
 
     try:
-        latest = git("describe", "--tags").decode().strip()
+        latest = git("describe", "--tags", "--first-parent", "--match", "[[:digit:]].[[:digit:]].[[:digit:]]*").decode().strip()
     except subprocess.CalledProcessError:
         # Default to version 1.0.0 if no tags are available
         version = "1.0.0"

--- a/version-update.py
+++ b/version-update.py
@@ -79,7 +79,7 @@ def main():
         version = "1.0.0"
     else:
         # Skip already tagged commits
-        if version_tag_on_commit:
+        if '-' not in latest:
             print(latest)
             return 0
 

--- a/version-update.py
+++ b/version-update.py
@@ -22,7 +22,7 @@ def extract_gitlab_url_from_project_url():
 def extract_merge_request_id_from_commit():
     message = git("log", "-1", "--pretty=%B")
     matches = re.search(r'(\S*\/\S*!)(\d+)', message.decode("utf-8"), re.M|re.I)
-    
+
     if matches == None:
         raise Exception(f"Unable to extract merge request from commit message: {message}")
 
@@ -66,20 +66,28 @@ def tag_repo(tag):
 
     git("remote", "set-url", "--push", "origin", push_url)
     git("tag", tag)
-    git("push", "origin", tag)        
+    git("push", "origin", tag)
 
 def main():
     env_list = ["CI_REPOSITORY_URL", "CI_PROJECT_ID", "CI_PROJECT_URL", "CI_PROJECT_PATH", "NPA_USERNAME", "NPA_PASSWORD"]
     [verify_env_var_presence(e) for e in env_list]
 
     try:
-        latest = git("describe", "--tags").decode().strip()
+        tags = git("tag", "--points-at", "HEAD").decode().strip().split()
+
+        r = re.compile("^\d+\.\d+\.\d+.*$")
+        latest = list(filter(r.match, tags))
+        version_tag_on_commit = latest
+
+        if not latest:
+            latest = git("describe", "--tags", "--first-parent", "--match", "[[:digit:]].[[:digit:]].[[:digit:]]*").decode().strip()
+
     except subprocess.CalledProcessError:
         # Default to version 1.0.0 if no tags are available
         version = "1.0.0"
     else:
         # Skip already tagged commits
-        if '-' not in latest:
+        if version_tag_on_commit:
             print(latest)
             return 0
 


### PR DESCRIPTION
Make sure that `git describe` returns a semver tag. Otherwise the version can't be bumped, e.g. on 'latest' or 'stable'.

Closes #10 