### PR TITLE
fix: allow tags with major/minor > 10

### DIFF
--- a/version-update.py
+++ b/version-update.py
@@ -73,7 +73,7 @@ def main():
     [verify_env_var_presence(e) for e in env_list]
 
     try:
-        latest = git("describe", "--tags", "--first-parent", "--match", "[[:digit:]].[[:digit:]].[[:digit:]]*").decode().strip()
+        latest = git("describe", "--tags", "--first-parent", "--match", "[[:digit:]]*.[[:digit:]]*.[[:digit:]]*").decode().strip()
     except subprocess.CalledProcessError:
         # Default to version 1.0.0 if no tags are available
         version = "1.0.0"


### PR DESCRIPTION
Find all tags in git repository not only those <10.<10.* This results in duplicate tags assigned by the program.
